### PR TITLE
Add command to update npm

### DIFF
--- a/cicd/python3nodejs/Dockerfile
+++ b/cicd/python3nodejs/Dockerfile
@@ -46,6 +46,10 @@ RUN yum repolist > /dev/null && \
     rpm -e --nodeps redhat-logos && \
     yum clean all -y
 
+# Update `npm` to a more mondern version that supports the `ci` option.
+# This will greatly speed up package installs in a ci environment.
+RUN npm i -g npm@latest
+
 # In order to drop the root user, we have to make some directories world
 # writable as OpenShift default security model is to run the container under
 # random UID.

--- a/cicd/python3nodejs/Dockerfile
+++ b/cicd/python3nodejs/Dockerfile
@@ -46,9 +46,12 @@ RUN yum repolist > /dev/null && \
     rpm -e --nodeps redhat-logos && \
     yum clean all -y
 
-# Update `npm` to a more mondern version that supports the `ci` option.
-# This will greatly speed up package installs in a ci environment.
-RUN npm i -g npm@latest
+# Update `npm` past what is supplied in `rh-nodejs6` to a more mondern
+# version that supports the `ci` option. This will greatly speed up
+# package installs in a ci environment. It also cleans the package
+# cache.
+RUN npm i -g npm@latest && \
+    rm -rf ~/.npm
 
 # In order to drop the root user, we have to make some directories world
 # writable as OpenShift default security model is to run the container under


### PR DESCRIPTION
In npm v5.7.0 they introduces a `ci` command that will greatly speed up package installation; in addition to this more modern versions of node are much faster at installing and managing packages. This command just updates npm past the version supplied by `rh-nodejs6`.